### PR TITLE
Found crash in encoding detection

### DIFF
--- a/CHCSVParser.m
+++ b/CHCSVParser.m
@@ -183,7 +183,7 @@ enum {
         fileEncoding = [self textEncodingForData:currentChunk offset:&offset];
         if (offset > 0) {
             // strip off the text encoding bytes
-            [currentChunk replaceBytesInRange:NSMakeRange(0, offset) withBytes:NULL];
+            [currentChunk replaceBytesInRange:NSMakeRange(0, offset) withBytes:NULL length:0];
         }
         [self extractStringFromCurrentChunk];
     }


### PR DESCRIPTION
One line change from

`````` replaceBytesInRange:withBytes:```
to
```replaceBytesInRange:withBytes:length:```
``````
