### PR TITLE
Small update to include delegate method for parse cancellation

### DIFF
--- a/CHCSVParser.h
+++ b/CHCSVParser.h
@@ -83,6 +83,7 @@
 
 - (void) parser:(CHCSVParser *)parser didReadField:(NSString *)field;
 
+- (void) parser:(CHCSVParser *)parser didCancelDocument:(NSString *)csvFile;
 - (void) parser:(CHCSVParser *)parser didEndDocument:(NSString *)csvFile;
 
 - (void) parser:(CHCSVParser *)parser didFailWithError:(NSError *)error;

--- a/CHCSVParser.m
+++ b/CHCSVParser.m
@@ -345,7 +345,7 @@ enum {
 	
 	if (error != nil) {
 		[[self parserDelegate] parser:self didFailWithError:error];
-	} else {
+	} else if (state != CHCSVParserStateCancelled) {
 		[[self parserDelegate] parser:self didEndDocument:[self csvFile]];
 	}
 	hasStarted = NO;
@@ -493,7 +493,7 @@ enum {
 	}
 	
 	[currentField trimCharactersInSet_csv:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-
+    
 	[currentField replaceOccurrencesOfString:@"\"\"" withString_csv:STRING_QUOTE];
 	
 	//replace all occurrences of regex: \\(.) with $1 (but not by using a regex)
@@ -524,6 +524,7 @@ enum {
 #pragma Cancelling
 
 - (void) cancelParsing {
+    [[self parserDelegate] parser:self didCancelDocument:[self csvFile]];
     SETSTATE(CHCSVParserStateCancelled)
 }
 

--- a/NSArray+CHCSVAdditions.m
+++ b/NSArray+CHCSVAdditions.m
@@ -69,6 +69,10 @@
 	[currentLine addObject:field];
 }
 
+- (void) parser:(CHCSVParser *)parser didCancelDocument:(NSString *)csvFile {
+	
+}
+
 - (void) parser:(CHCSVParser *)parser didEndDocument:(NSString *)csvFile {
 	
 }

--- a/main.m
+++ b/main.m
@@ -17,6 +17,9 @@
 - (void) parser:(CHCSVParser *)parser didEndLine:(NSUInteger)lineNumber {
 //	NSLog(@"Ending line: %lu", lineNumber);
 }
+- (void) parser:(CHCSVParser *)parser didCancelDocument:(NSString *)csvFile {
+    //	NSLog(@"parser canceled: %@", csvFile);
+}
 - (void) parser:(CHCSVParser *)parser didEndDocument:(NSString *)csvFile {
 //	NSLog(@"parser ended: %@", csvFile);
 }


### PR DESCRIPTION
This pull request adds a new delegate method to the CHCSVParserDelegate for notification when parse operation is cancelled.

Thanks for taking a look!

Aaron
