### PR TITLE
Fix dummy records created if the last character is line break

### DIFF
--- a/CHCSVParser/CHCSVParser.m
+++ b/CHCSVParser/CHCSVParser.m
@@ -280,7 +280,7 @@ NSString *const CHCSVErrorDomain = @"com.davedelong.csv";
     BOOL followedByNewline = [self _parseNewline];
     [self _endRecord];
     
-    return (followedByNewline && _error == nil);
+    return (followedByNewline && [self _peekCharacter]!='\0' && _error == nil);
 }
 
 - (BOOL)_parseNewline {

--- a/Test.csv
+++ b/Test.csv
@@ -19,3 +19,4 @@ This,has,mixed,"""escaped quotes\""
    This   ,   line   ,   has   ,   significant   ,   whitespace   
 This,is,the,last,line
 ,
+


### PR DESCRIPTION
The fix add the checking logic at the end of each line processing, if it reach the end ('\0' read), then stop the parse. 
