### PR TITLE
Add options to manage output as array of dictionaries

### DIFF
--- a/CHCSVParser/CHCSVParser.h
+++ b/CHCSVParser/CHCSVParser.h
@@ -57,6 +57,7 @@ typedef NSInteger CHCSVErrorCode;
 @property (assign) BOOL sanitizesFields; // default is NO
 @property (assign) BOOL recognizesComments; // default is NO
 @property (assign) BOOL stripsLeadingAndTrailingWhitespace; // default is NO
+@property (assign) BOOL firstLineAsKeys; // default is NO
 
 @property (readonly) NSUInteger totalBytesRead;
 
@@ -93,7 +94,8 @@ typedef NS_OPTIONS(NSUInteger, CHCSVParserOptions) {
     CHCSVParserOptionsRecognizesBackslashesAsEscapes = 1 << 0,
     CHCSVParserOptionsSanitizesFields = 1 << 1,
     CHCSVParserOptionsRecognizesComments = 1 << 2,
-    CHCSVParserOptionsStripsLeadingAndTrailingWhitespace = 1 << 3
+    CHCSVParserOptionsStripsLeadingAndTrailingWhitespace = 1 << 3,
+    CHCSVParserOptionsFirstLineAsKeys = 1 << 4
 };
 
 @interface NSArray (CHCSVAdditions)

--- a/UnitTests.m
+++ b/UnitTests.m
@@ -121,4 +121,31 @@
 	}
 }
 
+/**
+ * Tests the CS Parser with the option CHCSVParserOptionsFirstLineAsKeys
+ * Instead of an array of arrays it will generate an array of dicrionaries starting from index 1.
+ */
+
+- (void) testFirstLineAsKeys {
+	NSString *file = [[NSBundle bundleForClass:[self class]] pathForResource:@"Test" ofType:@"csv"];
+    
+    NSData *data = [NSData dataWithContentsOfFile:file];
+    
+    NSArray *parsedArray = [NSArray arrayWithContentsOfCSVFile:file options:CHCSVParserOptionsRecognizesBackslashesAsEscapes|CHCSVParserOptionsFirstLineAsKeys];
+    STAssertNotNil(parsedArray, @"Failed Parsing");
+    STAssertTrue((parsedArray.count > 0), @"Failed Parsing");
+    
+    NSDictionary *firstRealLine = [parsedArray objectAtIndex:0];
+    STAssertTrue(([firstRealLine isKindOfClass:[NSDictionary class]]), @"Lines are not Dictionaries");
+    
+    NSArray *expectedKeys = [[self expectedFields] objectAtIndex:0];
+    
+    STAssertTrue((firstRealLine.allKeys.count == expectedKeys.count), @"Keys count differ.  Expected %@, given %@", firstRealLine.allKeys.count, expectedKeys.count);
+    
+    [expectedKeys enumerateObjectsUsingBlock:^(id key, NSUInteger idx, BOOL *stop) {
+        id resultObj = [firstRealLine objectForKey:key];
+        STAssertNotNil(resultObj, @"OBject for Key %@ not found", key);
+    }];
+}
+
 @end


### PR DESCRIPTION
I find quite usefull to use the first line of a CSV as key columns for the rest of the document.
I added an options flag (CHCSVParserOptionsFirstLineAsKeys) to make that.
The result is an array of dictionaries starting from index 1 instead of an array of arrays starting form index 0.
I also added a unit test to handle the case. There are other 3 tests that fail, but they do so on Master branch as well.
