### PR TITLE
Minor improvement of memory using autoreleasepool

### DIFF
--- a/CHCSVParser/CHCSVParser.m
+++ b/CHCSVParser/CHCSVParser.m
@@ -277,17 +277,20 @@ NSString *const CHCSVErrorDomain = @"com.davedelong.csv";
         [self _parseComment];
     }
     
-    [self _beginRecord];
-    while (1) {
-        if (![self _parseField]) {
-            break;
+    BOOL followedByNewline;
+    @autoreleasepool {
+        [self _beginRecord];
+        while (1) {
+            if (![self _parseField]) {
+                break;
+            }
+            if (![self _parseDelimiter]) {
+                break;
+            }
         }
-        if (![self _parseDelimiter]) {
-            break;
-        }
-    }    
-    BOOL followedByNewline = [self _parseNewline];
-    [self _endRecord];
+        followedByNewline = [self _parseNewline];
+        [self _endRecord];
+    }
     
     return (followedByNewline && _error == nil);
 }


### PR DESCRIPTION
If you just run the main target (not the Unit Test) using the giant.csv and keep a look in memory consumption you can see it grows fast. Just enclosing the _beginRecord .. _endRecord inside an @autorelease block it solves it.
