### PR TITLE
Make things faster

### DIFF
--- a/CHCSVParser/CHCSVParser/CHCSVParser.m
+++ b/CHCSVParser/CHCSVParser/CHCSVParser.m
@@ -212,7 +212,7 @@ NSString *const CHCSVErrorDomain = @"com.davedelong.csv";
     NSUInteger reloadPortion = stringLength / 3;
     if (reloadPortion < 10) { reloadPortion = 10; }
     
-    if ([_stream hasBytesAvailable] && _nextIndex+reloadPortion >= stringLength) {
+    if (_nextIndex+reloadPortion >= stringLength && [_stream hasBytesAvailable]) {
         // read more from the stream
         uint8_t buffer[CHUNK_SIZE];
         NSInteger readBytes = [_stream read:buffer maxLength:CHUNK_SIZE];


### PR DESCRIPTION
A quick run of the profiler indicates that hasBytesAvailable is not
exactly fast. Adjusting the conditional it’s used in to short-circuit
it yields serious speed gains. In my test it went from 14s to 2s. Boom.