### PR TITLE
Added designated initializer to silence warnings in Xcode 7 GM

### DIFF
--- a/CHCSVParser/CHCSVParser.m
+++ b/CHCSVParser/CHCSVParser.m
@@ -569,6 +569,10 @@ NSString *const CHCSVErrorDomain = @"com.davedelong.csv";
     NSUInteger _currentField;
 }
 
+- (instancetype)init {
+    return [self init];
+}
+
 - (instancetype)initForWritingToCSVFile:(NSString *)path {
     NSOutputStream *stream = [NSOutputStream outputStreamToFileAtPath:path append:NO];
     return [self initWithOutputStream:stream encoding:NSUTF8StringEncoding delimiter:COMMA];


### PR DESCRIPTION
Added an override for designated initializer to silence a warning when using this class inside of a Swift-ObjC hybrid project in Xcode 7 GM, iOS 9.0