### PR TITLE
Fixed an exception when nil fields are sent to the exporter

### DIFF
--- a/CHCSVParser/CHCSVParser/CHCSVParser.m
+++ b/CHCSVParser/CHCSVParser/CHCSVParser.m
@@ -646,7 +646,7 @@ NSString *const CHCSVErrorDomain = @"com.davedelong.csv";
     }
     
     if (_currentLine == 0) {
-        [_firstLineKeys addObject:field];
+        [_firstLineKeys addObject:field?:@""];
     }
     
     NSString *string = field ? [field description] : @"";
@@ -740,7 +740,7 @@ NSString *const CHCSVErrorDomain = @"com.davedelong.csv";
 }
 
 - (void)parser:(CHCSVParser *)parser didReadField:(NSString *)field atIndex:(NSInteger)fieldIndex {
-    [self.currentLine addObject:field];
+    [self.currentLine addObject:field?:@""];
 }
 
 - (void)parser:(CHCSVParser *)parser didFailWithError:(NSError *)error {


### PR DESCRIPTION
The docs say it is alright to send empty strings an nils to the CSV Exporter - but nil fields in the first line cause exception, because _firstLineKeys NSArray won't accept nils. I followed the example of the next lines which replace nil with empty string - which is acceptable in the array. 

Same also in the CSVParser, although nil fields there can cause problems, especially if there are more than one. I think this "use first line as keys" should be re-thinked.