### PR TITLE
Add support for watchOS

### DIFF
--- a/CHCSVParser.podspec
+++ b/CHCSVParser.podspec
@@ -1,17 +1,18 @@
 Pod::Spec.new do |spec|
-    spec.name                  = "CHCSVParser"
-    spec.version               = "2.1.0"
-    spec.summary               = "A proper CSV parser for Objective-C"
-    spec.description           = <<-DESC
-                    	           A robust class for reading and writing delimited files in Cocoa.
-	                             DESC
-    spec.homepage              = "https://github.com/davedelong/CHCSVParser"
-    spec.license               = { :type => 'MIT', :file => 'LICENSE.txt' }
-    spec.author                = "Dave DeLong"
-    spec.social_media_url      = "http://twitter.com/davedelong"
-    spec.ios.deployment_target = "6.0"
-    spec.osx.deployment_target = "10.7"
-    spec.source                = { :git => "https://github.com/davedelong/CHCSVParser.git", :tag => "2.1.0" }
-    spec.source_files          = "CHCSVParser/CHCSVParser/CHCSVParser.{h,m}"
-    spec.requires_arc          = true
+    spec.name                      = "CHCSVParser"
+    spec.version                   = "2.1.0"
+    spec.summary                   = "A proper CSV parser for Objective-C"
+    spec.description               = <<-DESC
+                    	               A robust class for reading and writing delimited files in Cocoa.
+	                                 DESC
+    spec.homepage                  = "https://github.com/davedelong/CHCSVParser"
+    spec.license                   = { :type => 'MIT', :file => 'LICENSE.txt' }
+    spec.author                    = "Dave DeLong"
+    spec.social_media_url          = "http://twitter.com/davedelong"
+    spec.ios.deployment_target     = "6.0"
+    spec.osx.deployment_target     = "10.7"
+    spec.watchos.deployment_target = "1.0"
+    spec.source                    = { :git => "https://github.com/davedelong/CHCSVParser.git", :tag => "2.1.0" }
+    spec.source_files              = "CHCSVParser/CHCSVParser/CHCSVParser.{h,m}"
+    spec.requires_arc              = true
 end

--- a/README.markdown
+++ b/README.markdown
@@ -6,6 +6,7 @@
 
 - Mac OS X 10.7+
 - iOS 6+
+- watchOS 1.0+
 
 ## Usage
 


### PR DESCRIPTION
This PR added watchOS support as deployment target. Given that it supports iOS 6.0 and the first version of watchOS 1 was based on iOS 8.2, I set watchOS 1.0.

The addition doesn't break anything and it's still compatible.