### PR TITLE
Add watchOS support

### DIFF
--- a/CHCSVParser.podspec
+++ b/CHCSVParser.podspec
@@ -1,17 +1,18 @@
 Pod::Spec.new do |spec|
-    spec.name                  = "CHCSVParser"
-    spec.version               = "2.1.0"
-    spec.summary               = "A proper CSV parser for Objective-C"
-    spec.description           = <<-DESC
-                    	           A robust class for reading and writing delimited files in Cocoa.
-	                             DESC
-    spec.homepage              = "https://github.com/davedelong/CHCSVParser"
-    spec.license               = { :type => 'MIT', :file => 'LICENSE.txt' }
-    spec.author                = "Dave DeLong"
-    spec.social_media_url      = "http://twitter.com/davedelong"
-    spec.ios.deployment_target = "6.0"
-    spec.osx.deployment_target = "10.7"
-    spec.source                = { :git => "https://github.com/davedelong/CHCSVParser.git", :tag => "2.1.0" }
-    spec.source_files          = "CHCSVParser/CHCSVParser/CHCSVParser.{h,m}"
-    spec.requires_arc          = true
+    spec.name                      = "CHCSVParser"
+    spec.version                   = "2.1.0"
+    spec.summary                   = "A proper CSV parser for Objective-C"
+    spec.description               = <<-DESC
+                    	               A robust class for reading and writing delimited files in Cocoa.
+	                                 DESC
+    spec.homepage                  = "https://github.com/davedelong/CHCSVParser"
+    spec.license                   = { :type => 'MIT', :file => 'LICENSE.txt' }
+    spec.author                    = "Dave DeLong"
+    spec.social_media_url          = "http://twitter.com/davedelong"
+    spec.ios.deployment_target     = "6.0"
+    spec.osx.deployment_target     = "10.7"
+    spec.watchos.deployment_target = "1.0"
+    spec.source                    = { :git => "https://github.com/davedelong/CHCSVParser.git", :tag => "2.1.0" }
+    spec.source_files              = "CHCSVParser/CHCSVParser/CHCSVParser.{h,m}"
+    spec.requires_arc              = true
 end

--- a/README.markdown
+++ b/README.markdown
@@ -6,6 +6,7 @@
 
 - Mac OS X 10.7+
 - iOS 6+
+- watchOS 1.0+
 
 ## Usage
 


### PR DESCRIPTION
Added watchOS support to this forked repository so that our internal library can refer to the repository directory instead of tweaking the private spec.

Previously, I opened https://github.com/davedelong/CHCSVParser/pull/113, but it wasn't reviewed. We'd like to support Swift Package Manager so maintaining the forked repository would be better for us until we find a better solution.
ref: https://github.com/davedelong/CHCSVParser/pull/111